### PR TITLE
form.submitted secure deletion

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Changelog
 3.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Additional check in BaseControllerPageTemplate when we try to delete an entry
+  from the request, that has already been deleted [cekk]
 
 
 3.0.4 (2015-03-08)

--- a/Products/CMFFormController/BaseControllerPageTemplate.py
+++ b/Products/CMFFormController/BaseControllerPageTemplate.py
@@ -24,7 +24,8 @@ class BaseControllerPageTemplate(ControllerBase):
             controller_state = self.getButton(controller_state, REQUEST)
             validators = self.getValidators(controller_state, REQUEST).getValidators()
             controller_state = controller.validate(controller_state, REQUEST, validators)
-            del REQUEST.form['form.submitted']
+            if 'form.submitted' in REQUEST.form:
+                del REQUEST.form['form.submitted']
             return self.getNext(controller_state, REQUEST)
 
         kwargs['state'] = controller_state


### PR DESCRIPTION
I've found this bug in a strange setup:
Plone 4.3.4.1 + uwosh.pfg.d2c (PloneFormGen plugin for storing data in content-types) + a versioned d2c content.

When i submit the form, the process enter 2 times in BaseControllerPageTemplate for the same request. The second time is when is assigned the controller_state.
In this case, the BaseControllerPageTemplate is called another way. The second controller delete correctly the entry in the request, but when we return to the first controller, the entry has already deleted and an exception is raised.

With this simple check we can avoid the problem.