### PR TITLE
Move patch from plone.protect 3.x to Actions.RedirectTo

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,9 @@ Changelog
 3.0.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Move patch from plone.protect 3.x to Actions.RedirectTo so it allows ATContentTypes add forms to append auth token.
+  Issue https://github.com/plone/Products.CMFPlone/issues/1335
+  [staeff, fredvd]
 
 3.0.5 (2015-06-05)
 ------------------

--- a/Products/CMFFormController/Actions/RedirectTo.py
+++ b/Products/CMFFormController/Actions/RedirectTo.py
@@ -16,7 +16,19 @@ class RedirectTo(BaseFormAction):
             # No host specified, so url is relative.  Get an absolute url.
             url = urljoin(context.absolute_url()+'/', url)
         url = self.updateQuery(url, controller_state.kwargs)
-        return context.REQUEST.RESPONSE.redirect(url)
+        request = context.REQUEST
+        # this is mostly just for archetypes edit forms...
+        if 'edit' in url and '_authenticator' not in url and \
+                '_authenticator' in request.form:
+            if '?' in url:
+                url += '&'
+            else:
+                url += '?'
+            auth = request.form['_authenticator']
+            if isinstance(auth, list):
+                auth = auth[0]
+            url += '_authenticator=' + auth
+        return request.RESPONSE.redirect(url)
 
 
 registerFormAction('redirect_to',


### PR DESCRIPTION
so it allows ATContentTypes add forms to append auth token