### PR TITLE
Take over plone.protect RedirectTo patch [3.0]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New:
 
 Fixes:
 
-- *add item here*
+- Move patch from plone.protect 3.x to Actions.RedirectTo so it allows ATContentTypes add forms to append auth token.
+  Issue https://github.com/plone/Products.CMFPlone/issues/1335
+  [staeff, fredvd]
 
 
 3.0.6 (2016-04-09)

--- a/Products/CMFFormController/Actions/RedirectTo.py
+++ b/Products/CMFFormController/Actions/RedirectTo.py
@@ -16,7 +16,19 @@ class RedirectTo(BaseFormAction):
             # No host specified, so url is relative.  Get an absolute url.
             url = urljoin(context.absolute_url()+'/', url)
         url = self.updateQuery(url, controller_state.kwargs)
-        return context.REQUEST.RESPONSE.redirect(url)
+        request = context.REQUEST
+        # this is mostly just for archetypes edit forms...
+        if 'edit' in url and '_authenticator' not in url and \
+                '_authenticator' in request.form:
+            if '?' in url:
+                url += '&'
+            else:
+                url += '?'
+            auth = request.form['_authenticator']
+            if isinstance(auth, list):
+                auth = auth[0]
+            url += '_authenticator=' + auth
+        return request.RESPONSE.redirect(url)
 
 
 registerFormAction('redirect_to',


### PR DESCRIPTION
Move patch from plone.protect 3.x to Actions.RedirectTo so it allows ATContentTypes add forms to append auth token.

Replaces pull request #3 for branch 3.0.x