### PR TITLE
Take over plone.protect RedirectTo patch [master]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 3.1.2 (unreleased)
 ------------------
 
+
 Breaking changes:
 
 - *add item here*
@@ -14,7 +15,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Move patch from plone.protect 3.x to Actions.RedirectTo so it allows ATContentTypes add forms to append auth token.
+  Issue https://github.com/plone/Products.CMFPlone/issues/1335
+  [staeff, fredvd]
 
 
 3.1.1 (2016-08-12)

--- a/Products/CMFFormController/Actions/RedirectTo.py
+++ b/Products/CMFFormController/Actions/RedirectTo.py
@@ -16,7 +16,19 @@ class RedirectTo(BaseFormAction):
             # No host specified, so url is relative.  Get an absolute url.
             url = urljoin(context.absolute_url()+'/', url)
         url = self.updateQuery(url, controller_state.kwargs)
-        return context.REQUEST.RESPONSE.redirect(url)
+        request = context.REQUEST
+        # this is mostly just for archetypes edit forms...
+        if 'edit' in url and '_authenticator' not in url and \
+                '_authenticator' in request.form:
+            if '?' in url:
+                url += '&'
+            else:
+                url += '?'
+            auth = request.form['_authenticator']
+            if isinstance(auth, list):
+                auth = auth[0]
+            url += '_authenticator=' + auth
+        return request.RESPONSE.redirect(url)
 
 
 registerFormAction('redirect_to',


### PR DESCRIPTION
Move patch from plone.protect 3.x to Actions.RedirectTo so it allows ATContentTypes add forms to append auth token.

Replaces pull request #3 for branch master.

After this, it is easier to apply today's security hotfix patch.