### PR TITLE
Applied security hotfix 20160830 for redirect_to. [3.0]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,11 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Applied security hotfix 20160830 for ``redirect_to``.  This action
+  refuses to redirect to unknown external sites.  Added
+  ``redirect_to_external`` action in case someone *does* need to
+  redirect to an external site.  This option is also there in the
+  hotfix.  [maurits]
 
 
 3.0.7 (2016-08-31)

--- a/Products/CMFFormController/Actions/RedirectTo.py
+++ b/Products/CMFFormController/Actions/RedirectTo.py
@@ -1,20 +1,34 @@
 from BaseFormAction import BaseFormAction
+from Products.CMFCore.utils import getToolByName
 from Products.CMFFormController.FormController import registerFormAction
-from urlparse import urlparse, urljoin
+from urlparse import urljoin
+from urlparse import urlparse
+
 
 def factory(arg):
     """Create a new redirect-to action"""
     return RedirectTo(arg)
 
 
+def factory_external(arg):
+    """Create a new external-redirect-to action"""
+    return ExternalRedirectTo(arg)
+
+
 class RedirectTo(BaseFormAction):
+
+    allow_external_url = False
+
     def __call__(self, controller_state):
         url = self.getArg(controller_state)
         context = controller_state.getContext()
         # see if this is a relative url or an absolute
         if len(urlparse(url)[1]) == 0:
             # No host specified, so url is relative.  Get an absolute url.
-            url = urljoin(context.absolute_url()+'/', url)
+            url = urljoin(context.absolute_url() + '/', url)
+        elif (not self.allow_external_url
+              and not getToolByName(context, 'portal_url').isURLInPortal(url)):
+            url = context.absolute_url()
         url = self.updateQuery(url, controller_state.kwargs)
         request = context.REQUEST
         # this is mostly just for archetypes edit forms...
@@ -31,6 +45,19 @@ class RedirectTo(BaseFormAction):
         return request.RESPONSE.redirect(url)
 
 
-registerFormAction('redirect_to',
-                   factory,
-                   'Redirect to the URL specified in the argument (a TALES expression).  The URL can either be absolute or relative.')
+class ExternalRedirectTo(RedirectTo):
+
+    allow_external_url = True
+
+
+registerFormAction(
+    'redirect_to',
+    factory,
+    'Redirect to the URL specified in the argument (a TALES expression). '
+    'The URL can either be absolute or relative, and must be internal.')
+
+registerFormAction(
+    'external_redirect_to',
+    factory_external,
+    'Redirect to the URL specified in the argument (a TALES expression). '
+    'The URL can either be absolute or relative, and may be external.')

--- a/Products/CMFFormController/Actions/RedirectTo.py
+++ b/Products/CMFFormController/Actions/RedirectTo.py
@@ -26,9 +26,14 @@ class RedirectTo(BaseFormAction):
         if len(urlparse(url)[1]) == 0:
             # No host specified, so url is relative.  Get an absolute url.
             url = urljoin(context.absolute_url() + '/', url)
-        elif (not self.allow_external_url
-              and not getToolByName(context, 'portal_url').isURLInPortal(url)):
-            url = context.absolute_url()
+        elif not self.allow_external_url:
+            url_tool = getToolByName(context, 'portal_url', None)
+            # In tests, the url_tool may be a CMFCore one,
+            # which does not have isURLInPortal.
+            if (url_tool is not None
+                    and hasattr(url_tool, 'isURLInPortal')
+                    and not url_tool.isURLInPortal(url)):
+                url = context.absolute_url()
         url = self.updateQuery(url, controller_state.kwargs)
         request = context.REQUEST
         # this is mostly just for archetypes edit forms...

--- a/Products/CMFFormController/tests/testRedirectTo.py
+++ b/Products/CMFFormController/tests/testRedirectTo.py
@@ -1,0 +1,101 @@
+#
+# Test the RedirectTo action.
+#
+
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import TEST_USER_PASSWORD
+from plone.app.testing.bbb import PloneTestCase
+from plone.protect import createToken
+
+import transaction
+
+
+class TestRedirectToFunctional(PloneTestCase):
+    # Functional tests, using the folder_publish.cpy script from
+    # Products.CMFPlone, which could be persuaded to redirect to an external
+    # website, which is not what it is meant for.
+
+    def afterSetUp(self):
+        # Update settings.
+        # self.app = self.layer['app']
+        # self.portal = self.layer['portal']
+        # self.request = self.layer['request']
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        self.portal.portal_workflow.setChainForPortalTypes(
+            ('Document',),
+            ('simple_publication_workflow',))
+        # Create page.
+        self.portal.invokeFactory(
+            id='page',
+            title='Page 1',
+            type_name='Document'
+        )
+        self.page = self.portal.page
+
+    def beforeTearDown(self):
+        # Weird that we have to remove this page manually.  Otherwise with the
+        # second test we get an error:
+        # BadRequest: The id "page" is invalid - it is already in use.
+        # Strangely this does not happen when you run
+        # bin/test -s Products.CMFFormController -m testRedirectTo
+        # which is the only test case that uses portal.page,
+        # and it does happen when you run all the tests:
+        # bin/test -s Products.CMFFormController
+        # We may want to switch to the real plone.app.testing
+        # instead of bbb.PloneTestCase.
+        self.portal._delObject('page')
+        transaction.commit()
+
+    def test_regression(self):
+        csrf_token = createToken()
+        env = {'HTTP_X_CSRF_TOKEN': csrf_token}
+        target = 'front-page'
+        url = (
+            '%s/folder_publish'
+            '?workflow_action=publish'
+            '&paths=%s'
+            '&orig_template=%s') % (
+                '/'.join(self.portal.getPhysicalPath()),
+                '/'.join(self.page.getPhysicalPath()),
+                target
+        )
+        response = self.publish(
+            url,
+            basic='%s:%s' % (TEST_USER_NAME, TEST_USER_PASSWORD),
+            env=env,
+            extra={'orig_template': target,
+                   '_authenticator': csrf_token},
+            request_method='POST',
+            handle_errors=False,
+        )
+        self.assertNotEqual(response.headers.get('location'), None)
+        self.assertEqual(response.headers.get('location'),
+                         self.portal.absolute_url() + '/front-page')
+
+    def test_attacker_redirect(self):
+        csrf_token = createToken()
+        env = {'HTTP_X_CSRF_TOKEN': csrf_token}
+        target = 'http://attacker.com'
+        url = (
+            '%s/folder_publish'
+            '?workflow_action=publish'
+            '&paths=%s'
+            '&orig_template=%s') % (
+                '/'.join(self.portal.getPhysicalPath()),
+                '/'.join(self.page.getPhysicalPath()),
+                target
+        )
+        response = self.publish(
+            url,
+            basic='%s:%s' % (TEST_USER_NAME, TEST_USER_PASSWORD),
+            env=env,
+            extra={'orig_template': target,
+                   '_authenticator': csrf_token},
+            request_method='POST',
+            handle_errors=False,
+        )
+        self.assertNotEqual(response.headers.get('location'), None)
+        self.assertNotEqual(response.headers.get('location'),
+                            'http://attacker.com')


### PR DESCRIPTION
This action refuses to redirect to unknown external sites.  Added `redirect_to_external` action in case someone *does* need to redirect to an external site.
This option is also there in the hotfix.

We will need to wait with testing and merging this until https://github.com/plone/plone.protect/pull/53 has been merged, otherwise our `RedirectTo` will be overwritten by `plone.protect`.

But on 4.3 the tests should already pass, because 4.3 uses `plone.protect` 2.x, unless you use `plone4.csrffixes`.