### PR TITLE
deprecate confusing and hide unnecessary profiles.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,13 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Do only allow default profile to show up at site setup screen.
+  [jensens]
+
+- Deprecate profiles confusing name.
+  Old: Products.CMFFormController:CMFFormController.
+  New: Products.CMFFormController:default.
+  [jensens]
 
 
 3.1.4 (2017-02-12)

--- a/Products/CMFFormController/config.py
+++ b/Products/CMFFormController/config.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from Products.CMFCore.permissions import AddPortalContent
 
 ADD_CONTENT_PERMISSION = AddPortalContent

--- a/Products/CMFFormController/configure.zcml
+++ b/Products/CMFFormController/configure.zcml
@@ -17,4 +17,8 @@
   <five:deprecatedManageAddDelete
       class=".FSControllerPageTemplate.FSControllerPageTemplate" />
 
+  <utility
+      factory=".setuphandler.HiddenProfiles"
+      name="CMFFormController-hiddenprofiles" />
+
 </configure>

--- a/Products/CMFFormController/profiles.zcml
+++ b/Products/CMFFormController/profiles.zcml
@@ -4,11 +4,21 @@
     i18n_domain="plone">
 
   <genericsetup:registerProfile
+      name="default"
+      title="CMFFormController"
+      directory="profiles/default"
+      description="Install CMFFormController, an old-style way to create web-form flows."
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
+  <!-- BBB -->
+  <genericsetup:registerProfile
       name="CMFFormController"
       title="CMFFormController"
       directory="profiles/default"
       description="Extension profile for default CMFFormController setup."
       provides="Products.GenericSetup.interfaces.EXTENSION"
+      post_handler=".setuphandler.deprecate_profiles_confusing_name"
       />
 
   <genericsetup:registerProfile

--- a/Products/CMFFormController/setuphandler.py
+++ b/Products/CMFFormController/setuphandler.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from Products.CMFPlone.interfaces import INonInstallable
+from zope.interface import implementer
+
+import warnings
+
+
+@implementer(INonInstallable)
+class HiddenProfiles(object):
+
+    def getNonInstallableProfiles(self):
+        """Hide uninstall profile from site-creation and quickinstaller"""
+        return [
+            'Products.CMFFormController:uninstall',
+            # bbb:
+            'Products.CMFFormController:CMFFormController',
+        ]
+
+
+def deprecate_profiles_confusing_name(tool):
+    warnings.warn(
+        'The profile with id "Products.CMFFormController:CMFFormController" '
+        'was renamed to "Products.CMFFormController:default".',
+        DeprecationWarning
+    )


### PR DESCRIPTION
Do only allow wrong profile to show up at site setup screen.

Deprecate profiles confusing name.
Old: Products.CMFFormController:CMFFormController.
New: Products.CMFFormController:default.

Deprecated profiles to be removed at 4.x (master)