### PR TITLE
Removed security declaration for nonexistent method

### DIFF
--- a/Products/CMFFormController/ControllerPythonScript.py
+++ b/Products/CMFFormController/ControllerPythonScript.py
@@ -127,7 +127,7 @@ class ControllerPythonScript(BaseClass, ControllerBase):
     security.declareProtected('Change Python Scripts',
       'ZPythonScriptHTML_editAction',
       'ZPythonScript_setTitle', 'ZPythonScript_edit',
-      'ZPythonScriptHTML_upload', 'ZPythonScriptHTML_changePrefs')
+      'ZPythonScriptHTML_upload')
 
 
     def __init__(self, *args, **kwargs):

--- a/Products/CMFFormController/ControllerValidator.py
+++ b/Products/CMFFormController/ControllerValidator.py
@@ -116,7 +116,7 @@ class ControllerValidator(BaseClass, ControllerBase):
     security.declareProtected('Change Python Scripts',
       'ZPythonScriptHTML_editAction',
       'ZPythonScript_setTitle', 'ZPythonScript_edit',
-      'ZPythonScriptHTML_upload', 'ZPythonScriptHTML_changePrefs')
+      'ZPythonScriptHTML_upload')
 
 
     def __init__(self, *args, **kwargs):

--- a/news/3130.bugfix
+++ b/news/3130.bugfix
@@ -1,0 +1,4 @@
+Removed security declaration for nonexistent method ``ZPythonScriptHTML_changePrefs``.
+This method was removed from ``Products.PythonScripts`` in version 4.2, from October 2018.
+Added ``Products.PythonScripts>=4.2`` as dependency.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,6 @@ setup(
         'Acquisition',
         'transaction',
         'Zope2>=4.0.a2',
+        'Products.PythonScripts>=4.2',
     ],
 )


### PR DESCRIPTION
Warnings on startup:

```
Class Products.CMFFormController.ControllerPythonScript.ControllerPythonScript has a security declaration for nonexistent method 'ZPythonScriptHTML_changePrefs'
Class Products.CMFFormController.ControllerValidator.ControllerValidator has a security declaration for nonexistent method 'ZPythonScriptHTML_changePrefs'
```

This method was removed from `Products.PythonScripts` in version 4.2, from October 2018.
Added `Products.PythonScripts>=4.2` as dependency.