### PR TITLE
Tests: set request method to POST in a way that works on Plone 6 too

### DIFF
--- a/Products/CMFFormController/tests/testRedirectTo.py
+++ b/Products/CMFFormController/tests/testRedirectTo.py
@@ -7,8 +7,8 @@ from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
+from plone.testing.zope import Browser
 from plone.protect import createToken
-from plone.testing.z2 import Browser
 
 import transaction
 import unittest
@@ -98,6 +98,7 @@ class TestRedirectToFunctional(unittest.TestCase):
 
         # The same without the testbrowser
         self.assertIsNone(self.request.response.headers.get('location'))
+        self.request.environ["REQUEST_METHOD"] = "POST"
         self.request.REQUEST_METHOD = 'POST'
         self.request.form['workflow_action'] = 'publish'
         self.request.form['paths'] = path

--- a/news/3057.bugfix
+++ b/news/3057.bugfix
@@ -1,0 +1,2 @@
+Tests: set request method to POST in a way that works on Plone 6 as well.
+[maurits]


### PR DESCRIPTION
We (or I) don't want CMFFormController in Plone 6, but we need it for the moment while refactoring is not done yet.
This is part of that refactoring: cleaning up form controller scripts in CMFPlone.
Needs to be tested together with https://github.com/plone/Products.CMFPlone/pull/3184 and https://github.com/plone/plone.app.content/pull/213